### PR TITLE
Fix boundary condition when looping over columns

### DIFF
--- a/KFAST.h
+++ b/KFAST.h
@@ -365,10 +365,10 @@ void _KFAST(const uint8_t* __restrict const data, const int32_t cols, const int3
 		}
 
 		if (i < rows - 3) {
-			// for col (3) to (cols - 35)
+			// for col (3) to (cols - 34)
 			// jumping forward 32 cols at a time and also moving ptr forward 32 cols each time with it
 			// these calls to processCols MUST be inlined for best performance, even if your compiler thinks otherwise
-			for (j = 3; j < cols - 35; j += 32, ptr += 32) {
+			for (j = 3; j < cols - 34; j += 32, ptr += 32) {
 				processCols<true, nonmax_suppression>(num_corners, ptr, j, offsets, ushft, t,
 					cols, consec, corners, cur, keypoints, i, start_row);
 			}


### PR DESCRIPTION
When looping over columns in KFast, the algorithm checks that there are at least 32 + 3 (for the border) columns available. However, the correct condition would then be `j<=cols-35`, or simply `j<cols-34`.

To verify this, say we have an image with 35 columns. In the current version, the condition 'j<cols-35' would be '0<0', which is false, so the algorithm would not enter the for loop that uses the "full" version of processCols, although it should, because we have enough columns (columns 0-31 for the vectorized registers, and columns 32, 33, 34 for the border).

Now one could say that this error is harmless, since it will just make `processCols` a tiny bit slower, but that's unfortunately not the case.
Line 159 of process cols has:
  `last_cols_mask = (1 << (cols - j - 3)) - 1;`
and here, if cols is 35, this will amount to: `(1 << 32) -1`, which will overflow since 1<<32 can't be represented in 32 bits (with gcc the result of this is 1).